### PR TITLE
Sort league rating plots before rendering graphs

### DIFF
--- a/src/assets/javascripts/league-rating-graph.js
+++ b/src/assets/javascripts/league-rating-graph.js
@@ -16,6 +16,7 @@ leagueGraphs.forEach((canvas) => {
         y: leagueStats.ratings[rating]
       })
     }
+    ratingPlots.sort((a, b) => a[0] - b[0])
 
     let leagueDataset = {
       datasets:


### PR DESCRIPTION
The order matters to draw the line between plots. This is out of order in the backend due to ordering by creation date of participations instead of the game confirmation.